### PR TITLE
Use bundled AIS-catcher plugins and disable remote updates by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM ghcr.io/sdr-enthusiasts/docker-baseimage:base
 ARG TARGETPLATFORM TARGETOS TARGETARCH
 
 ENV S6_KILL_FINISH_MAXTIME=10000 \
-    UPDATE_PLUGINS=true
+    UPDATE_PLUGINS=false
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
@@ -134,6 +134,9 @@ RUN set -x && \
     # delete unnecessary qemu binaries to save lots of space
     { find /usr/bin -regex '/usr/bin/qemu-.*'  | grep -v qemu-arm | xargs rm -vf {} || true; } && \
     rm -rf /src/* /tmp/* /var/lib/apt/lists/*
+
+# Add plugins from the same image as the AIS-catcher binary.
+COPY --from=build /etc/AIS-catcher/plugins/ /etc/AIS-catcher/plugins/
 
 # add AIS-catcher and libairspyhf
 RUN \

--- a/README.md
+++ b/README.md
@@ -227,7 +227,8 @@ If the `AISCATCHER_CHANNELS` and `AISCATCHER_DECODER_XXXX` parameters listed abo
 | `FEEDER_LAT` or `SXFEEDER_LAT` (legacy) | Used for calculating ship distances on web page | Empty |
 | `FEEDER_LONG` or `SXFEEDER_LON` (legacy) | Used for calculating ship distances on web page | Empty |
 | `DISABLE_SHOWLASTMSG` | If set to `true`, the last NMEA0182 message option won't be shown on the website. | Empty, i.e., last message option is available on website |
-| `PLUGIN_UPDATE_INTERVAL` | Optional. Set this to the interval (for example, `30` (secs) or `5m` or `6h` or `3d`) to check the AIS-Catcher github repository for updates to the JavaScript web plugins. Set to `0` or `off` to disable checking. | `6h` |
+| `UPDATE_PLUGINS` | Set to `true` to download web plugins from the AIS-Catcher GitHub repository. By default, plugins are copied from the bundled AIS-Catcher image at startup. | `false` |
+| `PLUGIN_UPDATE_INTERVAL` | When `UPDATE_PLUGINS=true`, set this to the interval (for example, `30` (secs) or `5m` or `6h` or `3d`) to check the AIS-Catcher GitHub repository for updates to the JavaScript web plugins. Set to `0` or `off` to disable remote updates, including at startup. | `6h` |
 | `REFRESHRATE` | Refresh rate of the vessel data on the web page, in msec. Larger numbers reduce web page traffic, which can become an issue if there are a large number of vessels | `2500` (msec) |
 | `DISABLE_GEOJSON` | If set to `true`, no GeoJSON info will be available at <http://my_aiscatcher/geojson>. This is normally enabled if the parameter is omitted. | Empty (GeoJSON is default enabled) |
 | `ADSB_CONNECTOR` | Connect to a `beast` or `raw1090` ADS-B data stream to show aircraft on your AIS map. Format: `ADSB_CONNECTOR=<format>,<hostname>,<port>` where `<format>` is either `beast` or `raw1090`, and the `<hostname>` and `<port>` parameters indicate where the data comes from | Empty |
@@ -429,6 +430,10 @@ You can format the text in this file using [Markdown](https://www.markdownguide.
 We recommend mapping a volume (as shown in the sample `docker-compose.yml` file in this repo) to the `/data` directory. This will ensure that AIS-Catcher data will persist across restarts and container recreation.
 
 Web Plugins for AIS-Catcher can be placed in the `/data/plugins` directory.
+
+At each container start, bundled plugins are copied from `/etc/AIS-catcher/plugins` to `/data/plugins` so they match the AIS-Catcher binary in the image. Existing files with the same names are replaced if their contents differ, with numbered backups retained. Custom plugins with other names are preserved. This also happens when `PLUGIN_UPDATE_INTERVAL` is `0` or `off`.
+
+Automatic downloads from GitHub are disabled by default. To opt in, set `UPDATE_PLUGINS=true`; `PLUGIN_UPDATE_INTERVAL` defaults to `6h`. Downloaded plugins may require a newer AIS-Catcher version than the one in your image.
 
 ## Additional Statistics Dashboard with Prometheus and Grafana
 

--- a/rootfs/etc/s6-overlay/scripts/50-update-plugins
+++ b/rootfs/etc/s6-overlay/scripts/50-update-plugins
@@ -23,6 +23,24 @@ source /scripts/common
 
 export APPNAME="50-plugin-updates"
 
+# Refresh bundled plugins on every start, including when remote updates are disabled.
+# Keep custom plugins and back up changed files before replacing them.
+mkdir -p /data/plugins || exit 1
+set +o noglob
+for file in /etc/AIS-catcher/plugins/*; do
+    [[ -f "$file" ]] || continue
+    destination="/data/plugins/${file##*/}"
+    if ! cmp -s "$file" "$destination"; then
+        cp --backup=numbered "$file" "$destination" || exit 1
+        # The directory no longer represents the last downloaded Git commit.
+        rm -f /data/plugins/.last_commit
+    fi
+done
+set -o noglob
+
+# Apply backup retention even when remote updates are disabled.
+find /data/plugins -name '*.~*~' -mtime +"${BACKUP_RETENTION_TIME:-7}" -exec rm {} \;
+
 #shellcheck disable=SC2076
 if chk_disabled "${PLUGIN_UPDATE_INTERVAL,,}"; then
     s6wrap --quiet --timestamps --prepend="${APPNAME}" --args echo "Plugins Updating is disabled"

--- a/rootfs/etc/s6-overlay/scripts/check-plugin-updates
+++ b/rootfs/etc/s6-overlay/scripts/check-plugin-updates
@@ -24,7 +24,7 @@ source /scripts/common
 export APPNAME="check-plugin-updates"
 
 #shellcheck disable=SC2076
-if chk_disabled "${PLUGIN_UPDATE_INTERVAL,,}"; then
+if ! chk_enabled "${UPDATE_PLUGINS:-false}" || chk_disabled "${PLUGIN_UPDATE_INTERVAL,,}"; then
     exec sleep infinity
 fi
 

--- a/rootfs/scripts/update-plugins
+++ b/rootfs/scripts/update-plugins
@@ -38,10 +38,9 @@ else
   rm -f /data/plugins/refreshrate.pjs
 fi
 
-if ! chk_enabled "${UPDATE_PLUGINS}"
+if ! chk_enabled "${UPDATE_PLUGINS:-false}"
 then
   "${s6wrap[@]}" --args echo "UPDATE_PLUGINS is not set to true; skipping plugin updates"
-  update_refreshrate
   exit 0
 fi
 


### PR DESCRIPTION
Shipfeeder currently downloads plugins from AIS-catcher's default branch independently of the binary pinned in the container. This can leave the Web UI and plugins using incompatible APIs, as reported in https://github.com/jvde-github/AIS-catcher/issues/638.

Set `UPDATE_PLUGINS=false` by default and copy `/etc/AIS-catcher/plugins` from the same pinned image as the binary. At startup, refresh `/data/plugins` from these bundled files, including when remote updates are disabled. Replace differing bundled files with numbered backups, preserve custom plugins with other names, and apply backup retention. This also repairs stale bundled plugins in existing data volumes.

Remote updates remain available with `UPDATE_PLUGINS=true`. The periodic updater stays idle when disabled. Remove the undefined `update_refreshrate` call in the disabled-update path and document the defaults and overwrite behavior.

Validation:
- Passed startup checks in the Shipfeeder base image for a fresh volume, stale plugin replacement, numbered backups, custom plugin preservation, repeated startup, disabled intervals (`off` and `0`), periodic idle behavior, explicit remote opt-in, unset defaults, and backup retention. Git and sleep were stubbed to check dispatch without network access or delays.
- ShellCheck passed for all three changed scripts; `git diff --check` passed.
- Verified `/etc/AIS-catcher/plugins` exists in the exact pinned upstream image.
- Built the complete modified Dockerfile successfully for `linux/arm64` as `shipfeeder:pr268-test`.
- Started the complete image with its normal s6 entrypoint and UDP input. Verified all five bundled plugins match `/data/plugins`, automatic updates are disabled, and AIS-catcher starts successfully. Fresh startup also succeeded on an isolated network.
- Replayed a local AIS sample through UDP: the vessel appeared in `/ships.json` and the browser, and the real 60-second health check passed (472 packets; Docker also reported healthy).
- Headless Chromium loaded the actual Web UI without JavaScript/plugin errors. Opened the vessel card and verified Google, VesselFinder, and ShipXplorer actions are visible in its More menu.
- Started the complete image with an existing data volume and `PLUGIN_UPDATE_INTERVAL=off`, with no network access: stale bundled plugins were replaced and backed up, a custom plugin was preserved, and another restart created no redundant backup.
- Physical SDR reception, external feeder connections, and other CPU architectures were not tested.
